### PR TITLE
Improve editing experience

### DIFF
--- a/src/app/[postSlug]/page.tsx
+++ b/src/app/[postSlug]/page.tsx
@@ -68,7 +68,10 @@ export default async function PostPage({
     <PostPageShell>
       <PostHeaderSection>
         <TitleAndBackButtonWrapper>
-          <BackButton href="/">← go back</BackButton>
+          <PostActions>
+            <BackButton href="/">← go back</BackButton>
+            <BackButton href={`/editor/${postData.slug ?? postSlug}`}>edit</BackButton>
+          </PostActions>
           <PostTitle>{postData.title}</PostTitle>
           <PublishedAt>
             {new Date(postData.publishedAt).toLocaleDateString("en-US", {
@@ -89,6 +92,12 @@ export default async function PostPage({
     </PostPageShell>
   );
 }
+
+const PostActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
 
 const PublishedAt = styled.span`
   font-size: 0.875rem;

--- a/src/app/api/export-post/route.ts
+++ b/src/app/api/export-post/route.ts
@@ -1,8 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import fs from "fs/promises";
+import { randomUUID } from "crypto";
 import { toKebabCase } from "@/lib/toKebabCase";
 import { IPost } from "@/types";
+
+async function findPostSlugById(postsDir: string, id: string) {
+  let files: string[];
+
+  try {
+    files = await fs.readdir(postsDir);
+  } catch {
+    return undefined;
+  }
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+
+    try {
+      const raw = await fs.readFile(path.join(postsDir, file), "utf8");
+      const post = JSON.parse(raw) as Partial<IPost>;
+
+      if (post.id === id) {
+        return file.slice(0, -".json".length);
+      }
+    } catch {
+      // Ignore malformed post files while looking for this id.
+    }
+  }
+
+  return undefined;
+}
 
 export async function POST(request: NextRequest) {
   let body: unknown;
@@ -24,7 +52,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { title, doc } = body as { title: unknown; doc: unknown };
+  const { title, doc, id, originalSlug } = body as {
+    title: unknown;
+    doc: unknown;
+    id?: unknown;
+    originalSlug?: unknown;
+  };
 
   if (typeof title !== "string" || title.trim() === "") {
     return NextResponse.json(
@@ -40,13 +73,41 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  if (id !== undefined && (typeof id !== "string" || id.trim() === "")) {
+    return NextResponse.json(
+      { error: "`id` must be a non-empty string when provided" },
+      { status: 400 },
+    );
+  }
+
+  if (originalSlug !== undefined) {
+    if (typeof originalSlug !== "string") {
+      return NextResponse.json(
+        { error: "`originalSlug` must be a string when provided" },
+        { status: 400 },
+      );
+    }
+
+    if (!/^[\w-]+$/.test(originalSlug)) {
+      return NextResponse.json(
+        { error: "`originalSlug` is not a valid slug" },
+        { status: 400 },
+      );
+    }
+  }
+
   const post = doc as IPost;
+  const postId = typeof id === "string" ? id : randomUUID();
 
   const basename = toKebabCase(title);
   const filename = `${basename}.json`;
   const postsDir = path.join(process.cwd(), "posts");
   const filePath = path.join(postsDir, filename);
 
+  const existingSlug = await findPostSlugById(postsDir, postId);
+  const slugToDelete = existingSlug ?? originalSlug;
+
+  post.id = postId;
   post.title = title;
   post.slug = basename;
   post.publishedAt = new Date().toISOString();
@@ -54,6 +115,11 @@ export async function POST(request: NextRequest) {
   try {
     await fs.mkdir(postsDir, { recursive: true });
     await fs.writeFile(filePath, JSON.stringify(post, null, 2), "utf8");
+
+    if (slugToDelete && slugToDelete !== basename) {
+      const oldFilePath = path.join(postsDir, `${slugToDelete}.json`);
+      await fs.rm(oldFilePath, { force: true });
+    }
   } catch (err) {
     console.error("Failed to write post:", err);
     return NextResponse.json(
@@ -62,5 +128,5 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  return NextResponse.json({ ok: true, filename });
+  return NextResponse.json({ ok: true, filename, id: postId, slug: basename });
 }

--- a/src/app/api/export-post/route.ts
+++ b/src/app/api/export-post/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
-import path from "path";
-import fs from "fs/promises";
-import { randomUUID } from "crypto";
+import { type NextRequest, NextResponse } from "next/server";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { toKebabCase } from "@/lib/toKebabCase";
-import { IPost } from "@/types";
+import type { IPost } from "@/types";
 
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/export-post/route.ts
+++ b/src/app/api/export-post/route.ts
@@ -5,6 +5,9 @@ import { randomUUID } from "node:crypto";
 import { toKebabCase } from "@/lib/toKebabCase";
 import type { IPost } from "@/types";
 
+const FILE_ALREADY_EXISTS_ERROR_CODE = "EEXIST";
+const WRITE_FILE = "w";
+const WRITE_FILE_ONLY_IF_NEW = "wx";
 
 export async function POST(request: NextRequest) {
   let body: unknown;
@@ -70,7 +73,7 @@ export async function POST(request: NextRequest) {
 
   const postId = typeof id === "string" ? id : randomUUID();
 
-  const basename = toKebabCase(title);
+  const basename = toPostSlug(title);
   const filename = `${basename}.json`;
   const postsDir = path.join(process.cwd(), "posts");
   const filePath = path.join(postsDir, filename);
@@ -87,15 +90,32 @@ export async function POST(request: NextRequest) {
     publishedAt: new Date().toISOString(),
   };
 
+  const isSavingExistingSlug = slugToDelete === basename;
+  const writeFlag = isSavingExistingSlug
+    ? WRITE_FILE
+    : WRITE_FILE_ONLY_IF_NEW;
+
   try {
     await fs.mkdir(postsDir, { recursive: true });
-    await fs.writeFile(filePath, JSON.stringify(post, null, 2), "utf8");
+    await fs.writeFile(filePath, JSON.stringify(post, null, 2), {
+      encoding: "utf8",
+      flag: writeFlag,
+    });
 
     if (slugToDelete && slugToDelete !== basename) {
       const oldFilePath = path.join(postsDir, `${slugToDelete}.json`);
       await fs.rm(oldFilePath, { force: true });
     }
   } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+
+    if (error.code === FILE_ALREADY_EXISTS_ERROR_CODE) {
+      return NextResponse.json(
+        { error: `A post with slug \`${basename}\` already exists` },
+        { status: 409 },
+      );
+    }
+
     console.error("Failed to write post:", err);
     return NextResponse.json(
       { error: "Failed to write file" },
@@ -131,4 +151,14 @@ async function findPostSlugById(postsDir: string, id: string) {
   }
 
   return undefined;
+}
+
+const DEFAULT_POST_SLUG = "untitled";
+
+function toPostSlug(title: string) {
+  return (
+    toKebabCase(title)
+      // Remove leading and trailing hyphens.
+      .replace(/^-+|-+$/g, "") || DEFAULT_POST_SLUG
+  );
 }

--- a/src/app/api/export-post/route.ts
+++ b/src/app/api/export-post/route.ts
@@ -5,32 +5,6 @@ import { randomUUID } from "crypto";
 import { toKebabCase } from "@/lib/toKebabCase";
 import { IPost } from "@/types";
 
-async function findPostSlugById(postsDir: string, id: string) {
-  let files: string[];
-
-  try {
-    files = await fs.readdir(postsDir);
-  } catch {
-    return undefined;
-  }
-
-  for (const file of files) {
-    if (!file.endsWith(".json")) continue;
-
-    try {
-      const raw = await fs.readFile(path.join(postsDir, file), "utf8");
-      const post = JSON.parse(raw) as Partial<IPost>;
-
-      if (post.id === id) {
-        return file.slice(0, -".json".length);
-      }
-    } catch {
-      // Ignore malformed post files while looking for this id.
-    }
-  }
-
-  return undefined;
-}
 
 export async function POST(request: NextRequest) {
   let body: unknown;
@@ -80,23 +54,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (originalSlug !== undefined) {
-    if (typeof originalSlug !== "string") {
-      return NextResponse.json(
-        { error: "`originalSlug` must be a string when provided" },
-        { status: 400 },
-      );
-    }
-
-    if (!/^[\w-]+$/.test(originalSlug)) {
-      return NextResponse.json(
-        { error: "`originalSlug` is not a valid slug" },
-        { status: 400 },
-      );
-    }
+  if (originalSlug !== undefined && typeof originalSlug !== "string") {
+    return NextResponse.json(
+      { error: "`originalSlug` must be a string when provided" },
+      { status: 400 },
+    );
   }
 
-  const post = doc as IPost;
+  if (typeof originalSlug === "string" && !/^[\w-]+$/.test(originalSlug)) {
+    return NextResponse.json(
+      { error: "`originalSlug` is not a valid slug" },
+      { status: 400 },
+    );
+  }
+
   const postId = typeof id === "string" ? id : randomUUID();
 
   const basename = toKebabCase(title);
@@ -104,13 +75,17 @@ export async function POST(request: NextRequest) {
   const postsDir = path.join(process.cwd(), "posts");
   const filePath = path.join(postsDir, filename);
 
-  const existingSlug = await findPostSlugById(postsDir, postId);
+  const existingSlug =
+    typeof id === "string" ? await findPostSlugById(postsDir, id) : undefined;
   const slugToDelete = existingSlug ?? originalSlug;
 
-  post.id = postId;
-  post.title = title;
-  post.slug = basename;
-  post.publishedAt = new Date().toISOString();
+  const post: IPost = {
+    ...(doc as IPost),
+    id: postId,
+    title,
+    slug: basename,
+    publishedAt: new Date().toISOString(),
+  };
 
   try {
     await fs.mkdir(postsDir, { recursive: true });
@@ -129,4 +104,31 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ ok: true, filename, id: postId, slug: basename });
+}
+
+async function findPostSlugById(postsDir: string, id: string) {
+  let files: string[];
+
+  try {
+    files = await fs.readdir(postsDir);
+  } catch {
+    return undefined;
+  }
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+
+    try {
+      const raw = await fs.readFile(path.join(postsDir, file), "utf8");
+      const post = JSON.parse(raw) as Partial<IPost>;
+
+      if (post.id === id) {
+        return file.slice(0, -".json".length);
+      }
+    } catch {
+      // Ignore malformed post files while looking for this id.
+    }
+  }
+
+  return undefined;
 }

--- a/src/app/editor/EditorClient.tsx
+++ b/src/app/editor/EditorClient.tsx
@@ -11,12 +11,14 @@ import {
   PostHeaderSection,
   PostPageShell,
   PostTitleInput,
+  TitleAndBackButtonWrapper,
 } from "@/lib/postPageLayout";
 import { Button } from "@components/Button";
 
 interface EditorClientProps {
   initialTitle?: string;
   initialContent?: JSONContent;
+  initialPublishedAt?: string;
   postId?: string;
   originalSlug?: string;
 }
@@ -24,6 +26,7 @@ interface EditorClientProps {
 export default function EditorClient({
   initialTitle,
   initialContent,
+  initialPublishedAt,
   postId,
   originalSlug,
 }: EditorClientProps) {
@@ -82,18 +85,29 @@ export default function EditorClient({
 
   return (
     <PostPageShell>
-      <EditorBackButton type="button" onClick={handleBack}>
-        ← View post
-      </EditorBackButton>
       <PostHeaderSection>
-        <PostTitleInput
-          name="title"
-          placeholder="[untitled blog]"
-          autoComplete="off"
-          aria-label="Post title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-        />
+        <TitleAndBackButtonWrapper>
+          <EditorBackButton type="button" onClick={handleBack}>
+            ← View post
+          </EditorBackButton>
+          <PostTitleInput
+            name="title"
+            placeholder="[untitled blog]"
+            autoComplete="off"
+            aria-label="Post title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          {initialPublishedAt && (
+            <PublishedAt>
+              {new Date(initialPublishedAt).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </PublishedAt>
+          )}
+        </TitleAndBackButtonWrapper>
         <Clouds width="5120" height="357" />
       </PostHeaderSection>
       <PostBodyColumn>
@@ -109,10 +123,6 @@ export default function EditorClient({
 }
 
 const EditorBackButton = styled.button`
-  position: absolute;
-  top: 2rem;
-  left: var(--page-padding-inline);
-  z-index: 20;
   font: inherit;
   font-size: 1rem;
   font-weight: 600;
@@ -139,11 +149,17 @@ const EditorBackButton = styled.button`
   }
 `;
 
+const PublishedAt = styled.span`
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--header);
+`;
+
 const ButtonWrapper = styled.div`
   display: flex;
   gap: 1rem;
   position: absolute;
-  top: 2rem;
+  top: var(--post-page-padding-vertical);
   right: var(--page-padding-inline);
   z-index: 20;
 `;

--- a/src/app/editor/EditorClient.tsx
+++ b/src/app/editor/EditorClient.tsx
@@ -83,7 +83,7 @@ export default function EditorClient({
   return (
     <PostPageShell>
       <EditorBackButton type="button" onClick={handleBack}>
-        ← Back
+        ← View post
       </EditorBackButton>
       <PostHeaderSection>
         <PostTitleInput

--- a/src/app/editor/EditorClient.tsx
+++ b/src/app/editor/EditorClient.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import type { Editor, JSONContent } from "@tiptap/core";
 import styled from "styled-components";
 import Tiptap from "@components/TipTap";
+import Clouds from "@components/Clouds";
 import {
   PostBodyColumn,
+  PostHeaderSection,
   PostPageShell,
   PostTitleInput,
 } from "@/lib/postPageLayout";
@@ -14,19 +17,30 @@ import { Button } from "@components/Button";
 interface EditorClientProps {
   initialTitle?: string;
   initialContent?: JSONContent;
+  postId?: string;
+  originalSlug?: string;
 }
 
 export default function EditorClient({
   initialTitle,
   initialContent,
+  postId,
+  originalSlug,
 }: EditorClientProps) {
+  const router = useRouter();
   const [title, setTitle] = useState(initialTitle ?? "");
+  const [currentPostId, setCurrentPostId] = useState(postId);
+  const [currentSlug, setCurrentSlug] = useState(originalSlug);
   const editorRef = useRef<Editor | null>(null);
   const [exporting, setExporting] = useState(false);
 
   const handleEditorReady = useCallback((editor: Editor | null) => {
     editorRef.current = editor;
   }, []);
+
+  const handleBack = () => {
+    router.push(currentSlug ? `/${currentSlug}` : "/");
+  };
 
   const handleExport = async () => {
     const editor = editorRef.current;
@@ -38,7 +52,12 @@ export default function EditorClient({
       const res = await fetch("/api/export-post", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title, doc }),
+        body: JSON.stringify({
+          title,
+          doc,
+          id: currentPostId,
+          originalSlug: currentSlug,
+        }),
       });
 
       if (!res.ok) {
@@ -48,7 +67,10 @@ export default function EditorClient({
         return;
       }
 
-      const { filename } = await res.json();
+      const { filename, id, slug } = await res.json();
+      setCurrentPostId(id);
+      setCurrentSlug(slug);
+      router.replace(`/editor/${slug}`);
       alert(`Exported to posts/${filename}`);
     } catch (err) {
       console.error("Export error:", err);
@@ -60,14 +82,20 @@ export default function EditorClient({
 
   return (
     <PostPageShell>
-      <PostTitleInput
-        name="title"
-        placeholder="[untitled blog]"
-        autoComplete="off"
-        aria-label="Post title"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-      />
+      <EditorBackButton type="button" onClick={handleBack}>
+        ← Back
+      </EditorBackButton>
+      <PostHeaderSection>
+        <PostTitleInput
+          name="title"
+          placeholder="[untitled blog]"
+          autoComplete="off"
+          aria-label="Post title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <Clouds width="5120" height="357" />
+      </PostHeaderSection>
       <PostBodyColumn>
         <Tiptap onEditor={handleEditorReady} content={initialContent} />
       </PostBodyColumn>
@@ -80,10 +108,42 @@ export default function EditorClient({
   );
 }
 
+const EditorBackButton = styled.button`
+  position: absolute;
+  top: 2rem;
+  left: var(--page-padding-inline);
+  z-index: 20;
+  font: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--header) 50%, var(--accent));
+  text-decoration: none;
+  border: none;
+  border-radius: 0.5rem;
+  background: transparent;
+  padding: 0;
+  width: fit-content;
+  cursor: pointer;
+
+  transition:
+    color 0.15s ease,
+    text-decoration 0.15s ease;
+
+  &:hover {
+    color: var(--header);
+    text-decoration: underline;
+    text-decoration-color: var(--accent);
+    text-decoration-thickness: 2px;
+    text-decoration-style: solid;
+    text-underline-offset: 2px;
+  }
+`;
+
 const ButtonWrapper = styled.div`
   display: flex;
   gap: 1rem;
   position: absolute;
-  top: var(--post-page-padding-vertical);
+  top: 2rem;
   right: var(--page-padding-inline);
+  z-index: 20;
 `;

--- a/src/app/editor/[[...postSlug]]/page.tsx
+++ b/src/app/editor/[[...postSlug]]/page.tsx
@@ -34,6 +34,7 @@ export default async function EditorPage({
     <EditorClient
       initialTitle={post.title}
       initialContent={doc}
+      initialPublishedAt={post.publishedAt}
       postId={post.id}
       originalSlug={post.slug ?? slug}
     />

--- a/src/app/editor/[[...postSlug]]/page.tsx
+++ b/src/app/editor/[[...postSlug]]/page.tsx
@@ -30,5 +30,12 @@ export default async function EditorPage({
     content: post.content as unknown as JSONContent[],
   };
 
-  return <EditorClient initialTitle={post.title} initialContent={doc} />;
+  return (
+    <EditorClient
+      initialTitle={post.title}
+      initialContent={doc}
+      postId={post.id}
+      originalSlug={post.slug ?? slug}
+    />
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,10 @@ export default function HomePage() {
           <SectionTitle>Posts</SectionTitle>
           {posts.map((post) => (
             <PostChip key={post.slug}>
-              <PostTitle href={`/${post.slug}`}>{post.title}</PostTitle>
+              <PostTitleRow>
+                <PostTitle href={`/${post.slug}`}>{post.title}</PostTitle>
+                {isDev && <EditPostLink href={`/editor/${post.slug}`}>edit</EditPostLink>}
+              </PostTitleRow>
               <p>
                 {new Date(post.publishedAt).toLocaleDateString("en-US", {
                   year: "numeric",
@@ -164,6 +167,13 @@ const PostChip = styled.article`
   color: var(--foreground);
 `;
 
+const PostTitleRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+`;
+
 const PostTitle = styled(Link)`
   display: inline-block;
   font-size: 1.35rem;
@@ -184,6 +194,19 @@ const PostTitle = styled(Link)`
 const PostDescription = styled.p`
   font-size: 0.95rem;
   line-height: 1.6;
+`;
+
+const EditPostLink = styled(Link)`
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--foreground) 55%, var(--accent));
+  text-decoration: none;
+
+  &:hover {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
 `;
 
 const CreatePostButton = styled(ButtonLink)`

--- a/src/lib/postPageLayout.tsx
+++ b/src/lib/postPageLayout.tsx
@@ -22,27 +22,29 @@ export const PostTitle = styled.h1`
   font-size: clamp(1.5rem, 1rem + 10vw, 4rem);
   line-height: 1;
   font-weight: 800;
+  margin: 0;
 `;
 
 /**
  * Title field for the editor — same type metrics as `PostTitle`, input chrome removed
  * so it reads like the post heading.
  */
-export const PostTitleInput = styled.input.attrs({ type: "text" })`
+export const PostTitleInput = styled.textarea.attrs({ rows: 1 })`
   font-size: clamp(1.5rem, 1rem + 10vw, 4rem);
   line-height: 1;
   font-weight: 800;
   font-family: inherit;
   width: 100%;
+  min-height: 1em;
   margin: 0;
   padding: 0;
   border: none;
+  resize: none;
+  field-sizing: content;
   background: transparent;
   color: inherit;
   outline: none;
   box-shadow: none;
-  padding-inline: var(--page-padding-inline);
-  padding-top: var(--post-page-padding-vertical);
   font-family: var(--font-yang-bagus), Arial, Helvetica, sans-serif;
 
   &::placeholder {

--- a/src/lib/toKebabCase.ts
+++ b/src/lib/toKebabCase.ts
@@ -7,14 +7,11 @@
  * - Falls back to "untitled" if result is empty
  */
 export function toKebabCase(title: string): string {
-  return (
-    title
-      .toString()
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, "-") // Replace spaces with -
-      .replace(/[^\w-]+/g, "") // Remove all non-word chars (except -)
-      .replace(/--+/g, "-") // Replace multiple - with single -
-      .replace(/^-+|-+$/g, "") || "untitled"
-  );
+  return title
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-") // Replace spaces with -
+    .replace(/[^\w-]+/g, "") // Remove all non-word chars (except -)
+    .replace(/--+/g, "-"); // Replace multiple - with single -
 }

--- a/src/lib/toKebabCase.ts
+++ b/src/lib/toKebabCase.ts
@@ -7,11 +7,14 @@
  * - Falls back to "untitled" if result is empty
  */
 export function toKebabCase(title: string): string {
-  return title
-    .toString()
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-") // Replace spaces with -
-    .replace(/[^\w-]+/g, "") // Remove all non-word chars (except -)
-    .replace(/--+/g, "-"); // Replace multiple - with single -
+  return (
+    title
+      .toString()
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, "-") // Replace spaces with -
+      .replace(/[^\w-]+/g, "") // Remove all non-word chars (except -)
+      .replace(/--+/g, "-") // Replace multiple - with single -
+      .replace(/^-+|-+$/g, "") || "untitled"
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { JSONContent } from "@tiptap/core";
 
 export interface IPost {
+  id?: string;
   title: string;
   slug: string;
   content: JSONContent;


### PR DESCRIPTION
## Summary

Opening a quick PR to demo how my coding workflow works + how i use https://pi.dev 

<img src="https://github.com/user-attachments/assets/409f60c9-66be-465c-930c-4e69aaaccb5e" width="800" />

---

Makes editing existing posts smoother:

- You can jump into edit mode from the post page.
- You can jump back to the published post from the editor.
- The editor looks like the post page, so switching modes feels stable.
- Saving an existing post updates the same post instead of creating a duplicate.
- Renaming a post updates its URL and removes the old JSON file.
- New post exports fail instead of overwriting an existing JSON file when slugs collide.

<img src="https://github.com/user-attachments/assets/c0a90ede-c723-4dd1-861f-a19957707fba" width="800" />
